### PR TITLE
Obtain the "feed" URL by removing "issues.atom" instead of "/issues.a…

### DIFF
--- a/src/TurtleMineShared/FeedParser.cs
+++ b/src/TurtleMineShared/FeedParser.cs
@@ -42,7 +42,7 @@ namespace TurtleMine
 			}
 
 			//Remove BaseRedmineUrl and "Issues" wording
-			projectUrlPath = feed.Links[0].Uri.AbsoluteUri.Replace(baseRedmineUrl, String.Empty).Replace("/issues.atom", String.Empty).Replace("/issues", String.Empty);
+			projectUrlPath = feed.Links[0].Uri.AbsoluteUri.Replace(baseRedmineUrl, String.Empty).Replace("issues.atom", String.Empty).Replace("/issues", String.Empty);
 
 			//Also remove Url Query info if exists
 			if (!String.IsNullOrEmpty(feed.Links[0].Uri.Query))


### PR DESCRIPTION
…tom".

The feed.Links[0].Uri.AbsoluteUri (line 45) fo not contains the first "/" character, the replacement cannot be done.
If the character in contained, an extra "/" will be present on the URL. It is not a problem since the URL format is roust to that.